### PR TITLE
[TM first] Halo PVE shrap rework port + Muzzle Flash Attach Fix

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1887,7 +1887,7 @@ not all weapons use normal magazines etc. load_into_chamber() itself is designed
 	if(!istype(gun_user) || !isturf(gun_user.loc))
 		return
 	if(muzzle_flash && !muzzle_flash.applied)
-		var/atom/movable/flash_loc = gun_user.loc
+		var/atom/movable/flash_loc = gun_user
 		var/prev_light = light_range
 		if(!light_on && (light_range <= muzzle_flash_lum))
 			set_light_range(muzzle_flash_lum)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1032,7 +1032,7 @@
 		return
 
 	P.play_hit_effect(src)
-	if(damage || (ammo_flags & AMMO_SPECIAL_EMBED))
+	if(damage_result || (ammo_flags & AMMO_SPECIAL_EMBED))
 
 		var/splatter_dir = get_dir(P.starting, loc)
 		handle_blood_splatter(splatter_dir)
@@ -1040,7 +1040,7 @@
 		. = TRUE
 		apply_damage(damage_result, P.ammo.damage_type, P.def_zone, firer = P.firer)
 
-		if(P.ammo.shrapnel_chance > 0 && prob(P.ammo.shrapnel_chance + floor(damage / 10)))
+		if(P.ammo.shrapnel_chance > 0 && (damage_result/damage) > 0.5 && prob(trunc(P.ammo.shrapnel_chance * damage_result/damage)))
 			if(ammo_flags & AMMO_SPECIAL_EMBED)
 				P.ammo.on_embed(src, organ)
 


### PR DESCRIPTION

# About the pull request

Портирует переделку шрапнели из [Halo PVE #141](https://github.com/cmss13-devs/cmss13-pve-halo/pull/141), конкретно вот [этот](https://github.com/cmss13-devs/cmss13-pve-halo/pull/141/changes#diff-9ceb3c38494846ab96dde561802292b1a70d28016e890752927f323253fad8fc) файл

> Modifies shrapnel embed code. Now shrapnel has a chance to embed based on base chance modified by how much damage it did; for the sake of gameplay 50% or less is considered nonpenetrating and will just glance off.

edit 31.05

Порт ПР-а Tyeagg-а, с фиксацией вспышки не на последнем тайле, а на юзере непосредственно

# Explain why it's good for the game

IDK, шрапнель теперь будет не столь вопиющей? Из-за изменения формулы с начального урона на конечное значение, тяжелобронированные дубины теперь не будут умирать из-за того что в них высадили три обоймы ПП, и шрапнель от неё наносила больше урона чем сами пули.

editt 31.05
Smoo-ooo-th

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
code: Projectiles now embed based on their dealt damage.
fix: muzzle flash attaches to firer now
/:cl:
