### PR TITLE
Gun balance schizophrenia strikes back

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -122,9 +122,10 @@
 	)
 
 /obj/item/weapon/gun/rifle/m41a/elite/set_gun_config_values()
+	..()
 	set_fire_delay(FIRE_DELAY_TIER_11)
-	set_burst_amount(BURST_AMOUNT_TIER_3)
-	set_burst_delay(FIRE_DELAY_TIER_11)
+	set_burst_amount(BURST_AMOUNT_TIER_2)
+	set_burst_delay(FIRE_DELAY_TIER_12)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_10 + 2*HIT_ACCURACY_MULT_TIER_1
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_7
 	scatter = SCATTER_AMOUNT_TIER_10
@@ -147,7 +148,7 @@
 
 /obj/item/weapon/gun/rifle/m41a/elite/unloaded/platoon
 	flags_gun_features = GUN_AUTO_EJECTOR|GUN_CAN_POINTBLANK|GUN_AMMO_COUNTER|GUN_TRIGGER_SAFETY
-	starting_attachment_types = list(/obj/item/attachable/stock/rifle/collapsible, /obj/item/attachable/attached_gun/grenade/mk1)
+	starting_attachment_types = list(/obj/item/attachable/stock/rifle/collapsible)
 	random_rail_chance = 50
 	random_spawn_rail = list(
 		/obj/item/attachable/reddot,
@@ -156,6 +157,11 @@
 	random_siderail_chance = 50
 	random_spawn_siderail = list(
 		/obj/item/attachable/lasersight,
+	)
+	random_under_chance = 100
+	random_spawn_under = list(
+		/obj/item/attachable/verticalgrip,
+		/obj/item/attachable/angledgrip,
 	)
 	random_muzzle_chance = 50
 	random_spawn_muzzle = list(
@@ -297,13 +303,13 @@
 	..()
 	set_fire_delay(FIRE_DELAY_TIER_10)
 	set_burst_amount(BURST_AMOUNT_TIER_3)
-	set_burst_delay(FIRE_DELAY_TIER_LMG)
+	set_burst_delay(FIRE_DELAY_TIER_11)
 	accuracy_mult = BASE_ACCURACY_MULT + HIT_ACCURACY_MULT_TIER_10
 	accuracy_mult_unwielded = BASE_ACCURACY_MULT - HIT_ACCURACY_MULT_TIER_7
 	scatter = SCATTER_AMOUNT_TIER_10
 	burst_scatter_mult = SCATTER_AMOUNT_TIER_10
 	scatter_unwielded = SCATTER_AMOUNT_TIER_2
-	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_2
+	damage_mult = BASE_BULLET_DAMAGE_MULT + BULLET_DAMAGE_MULT_TIER_5
 	recoil_unwielded = RECOIL_AMOUNT_TIER_2
 	damage_falloff_mult = 0
 	fa_max_scatter = SCATTER_AMOUNT_TIER_7

--- a/code/modules/projectiles/guns/smartgun.dm
+++ b/code/modules/projectiles/guns/smartgun.dm
@@ -318,7 +318,7 @@
 		ammo = ammo_tertiary
 		to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire impact-detonating rounds, which stagger most human-sized hostiles on hit and slow them down.")
 		balloon_alert(user, "firing impact-detonating")
-		drain += 100
+		drain += 10
 	else
 		ammo = ammo_primary
 		to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire highly precise rounds. These rounds are accurate and cost less power to operate.")
@@ -763,12 +763,12 @@
 		ammo = ammo_secondary
 		to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire armor-piercing rounds, offering greater penetration against armored targets compared to other rounds.")
 		balloon_alert(user, "firing armor-piercing")
-		drain += 100
+		drain += 50
 	else if(ammo == ammo_secondary)
 		ammo = ammo_tertiary
 		to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire flak rounds, which release a rain of heavy shrapnel.")
 		balloon_alert(user, "firing flak")
-		drain += 150
+		drain += 100
 	else
 		ammo = ammo_primary
 		to_chat(user, "[icon2html(src, usr)] You changed \the [src]'s ammo preparation procedures. You now fire highly precise rounds. These rounds are accurate and cost less power to operate.")

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -13,7 +13,7 @@
 	item_state = "generic_mag"
 	w_class = SIZE_MEDIUM
 	default_ammo = /datum/ammo/bullet/rifle
-	max_rounds = 50
+	max_rounds = 60
 	gun_type = /obj/item/weapon/gun/rifle/m41a
 	ammo_band_icon = "+m41a_band"
 	ammo_band_icon_empty = "+m41a_band_e"
@@ -22,7 +22,7 @@
 	name = "\improper M41A LE extended magazine (10x24mm)"
 	desc = "A 10mm assault Light Explosive extended rifle magazine."
 	icon_state = "m41a_extended"
-	max_rounds = 60
+	max_rounds = 85
 	bonus_overlay = "m41a_ex"
 
 /obj/item/ammo_magazine/rifle/incendiary


### PR DESCRIPTION
# About the pull request

Хотел изначально сделать ПР на повышение патрон в обоймах МК2 с 50/60 до 60/85 (normal/extended), но потом вспомнил про СГ и то что у него сжирается к хуям батарея.
Посмотрел в репо оффов и вставил нужные значения.

Слинг также хочу ревёртнуть, как минимум потому что заебёшься вставлять новое значение оффсета, а как максимум то что он обесценивает магнитку как модуль, но это вынешу в другой ПР.

# Explain why it's good for the game

QOL(?), в случае магазинов. Остальное смотреть выше.

# Testing Photographs and Procedure
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
balance: fixed SG enermous drain rate on secondary and tertiary mods.
balance: increased magazine size on M41 MK2 from 50/60 to 60/85 (normal/extended)
balance: removed UGL from spawning on PMC M41 MK2s.
balance: damage multiplier of PMC NSG-23 increased from 1.1 to 1.25, in exchange of slower ROF on burst mode (0.2 instead of 0.15)
/:cl:
