### PR TITLE
Medical scans automatically apply triage holocards, port from PVP.

### DIFF
--- a/code/__DEFINES/client_prefs.dm
+++ b/code/__DEFINES/client_prefs.dm
@@ -54,3 +54,12 @@
 #define DUAL_WIELD_SWAP 1
 ///Do nothing when dual wielding
 #define DUAL_WIELD_NONE 2
+
+//auto_holotag from /datum/preferences
+//=================================================
+/// Do not tag patients automatically
+#define NEVER_TAG_PATIENTS 0
+/// Only tag patients after scanning them in a bodyscanner (not a handheld scanner)
+#define BODYSCAN_TAG_PATIENTS 1
+/// Auto tag patients with triage tags upon scanning
+#define ALWAYS_TAG_PATIENTS 2

--- a/code/__DEFINES/human.dm
+++ b/code/__DEFINES/human.dm
@@ -103,6 +103,11 @@
 #define LIMB_PRINTING_TIME 550
 #define LIMB_METAL_AMOUNT 125
 
+// Holocard defines
+#define HOLOCARD_ACCURACY_HANDHELD 0
+#define HOLOCARD_ACCURACY_MANUAL 1
+#define HOLOCARD_ACCURACY_BODYSCANNER 2 //! Bodyscanners will always be able to set the correct holotag
+
 // ORDERS
 #define COMMAND_ORDER_RANGE 7
 #define COMMAND_ORDER_COOLDOWN 800

--- a/code/game/machinery/medical_pod/bodyscanner.dm
+++ b/code/game/machinery/medical_pod/bodyscanner.dm
@@ -199,6 +199,10 @@
 	else
 		last_health_display.target_mob = H
 
+	// Handle automatic holotags
+	if (user.client?.prefs.auto_holotag >= BODYSCAN_TAG_PATIENTS)
+		H.auto_assign_holotag(user, HOLOCARD_ACCURACY_BODYSCANNER)
+
 	N.fields["last_tgui_scan_result"] = last_health_display.ui_data(user, DETAIL_LEVEL_BODYSCAN)
 	N.fields["autodoc_data"] = generate_autodoc_surgery_list(H)
 	visible_message(SPAN_NOTICE("\The [src] pings as it stores the scan report of [H.real_name]"))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -101,6 +101,12 @@ FORENSIC SCANNER
 			last_health_display = new(M)
 		else
 			last_health_display.target_mob = M
+
+		// Handle automatic holotags
+		if (user?.client.prefs.auto_holotag >= ALWAYS_TAG_PATIENTS && istype(M, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = M
+			human.auto_assign_holotag(user, HOLOCARD_ACCURACY_HANDHELD)
+
 		SStgui.close_user_uis(user, src)
 		last_scan = last_health_display.ui_data(user, DETAIL_LEVEL_HEALTHANALYSER)
 		last_health_display.look_at(user, DETAIL_LEVEL_HEALTHANALYSER, bypass_checks = FALSE, ignore_delay = FALSE, alien = alien, associated_equipment = src)
@@ -409,6 +415,12 @@ FORENSIC SCANNER
 				SStgui.close_user_uis(connected_from, src)
 				last_scan = last_health_display.ui_data(connected_from, DETAIL_LEVEL_HEALTHANALYSER)
 				last_health_display.look_at(connected_from, DETAIL_LEVEL_HEALTHANALYSER, bypass_checks = TRUE, ignore_delay = FALSE, alien = alien, associated_equipment = src)
+
+		// Handle automatic holotags
+		if(connected_from?.client?.prefs?.auto_holotag >= ALWAYS_TAG_PATIENTS && istype(connected_to, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = connected_to
+			human.auto_assign_holotag(connected_from, HOLOCARD_ACCURACY_HANDHELD)
+
 		src.add_fingerprint()
 		if(last_scan && record_scan_on_connect)
 			record_scan_on_connect = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(whitelisted_client_procs, list(
 	/client/proc/toggle_clickdrag_override,
 	/client/proc/toggle_pb_override,
 	/client/proc/toggle_dualwield,
+	/client/proc/toggle_auto_holotag,
 	/client/proc/toggle_middle_mouse_swap_hands,
 	/client/proc/toggle_vend_item_to_hand,
 	/client/proc/switch_item_animations,

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 	var/ghost_vision_pref = GHOST_VISION_LEVEL_MID_NVG
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/dual_wield_pref = DUAL_WIELD_FIRE
-
+	var/auto_holotag = ALWAYS_TAG_PATIENTS
 	//Synthetic specific preferences
 	var/synthetic_name = "Undefined"
 	var/synthetic_type = SYNTH_GEN_THREE
@@ -670,6 +670,7 @@ GLOBAL_LIST_INIT(bgstate_options, list(
 					</b> <a href='byond://?_src_=prefs;preference=toggle_prefs;flag=[TOGGLE_AMMO_DISPLAY_TYPE]'><b>[toggle_prefs & TOGGLE_AMMO_DISPLAY_TYPE ? "On" : "Off"]</b></a><br>"
 			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations Detail Level</a><br>"
 			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Dual Wield Functionality</a><br>"
+			dat += "<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_holotag'>Toggle Auto Holotags</a><br>"
 		if(MENU_SPECIAL) //wart
 			dat += "<div id='column1'>"
 			dat += "<h2><b><u>ERT Settings:</u></b></h2>"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -279,6 +279,7 @@
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_clickdrag_override'>Toggle Combat Click-Drag Override</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_pb_override'>Toggle Combat Point-Blank Override</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_dualwield'>Toggle Alternate-Fire Dual Wielding</a><br>",
+		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_auto_holotag'>Toggle Auto Holotags</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_middle_mouse_swap_hands'>Toggle Middle Mouse Swapping Hands</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/toggle_vend_item_to_hand'>Toggle Vendors Vending to Hands</a><br>",
 		"<a href='byond://?src=\ref[src];action=proccall;procpath=/client/proc/switch_item_animations'>Toggle Item Animations</a><br>",
@@ -398,6 +399,24 @@
 			to_chat(src, SPAN_BOLDNOTICE("Dual-wielding now has no effect on how you fire."))
 
 	prefs.save_preferences()
+
+// Toggles whether or not using a body scanner/handheld scanner applies a triage tag to patients automatically
+
+/client/proc/toggle_auto_holotag()
+	switch (prefs.auto_holotag) {
+		if(NEVER_TAG_PATIENTS)
+			prefs.auto_holotag = ALWAYS_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Body scanners and handheld scanners will now automatically apply holocards."))
+		if(ALWAYS_TAG_PATIENTS)
+			prefs.auto_holotag = BODYSCAN_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Only body scanners will automatically apply triage holocards."))
+		if(BODYSCAN_TAG_PATIENTS)
+			prefs.auto_holotag = NEVER_TAG_PATIENTS
+			to_chat(src, SPAN_BOLDNOTICE("Triage holocards will never be automatically applied by health scanning devices."))
+		else
+			// Redundancy case, if defines ever get changed
+			prefs.auto_holotag = ALWAYS_TAG_PATIENTS
+	}
 
 /client/proc/toggle_middle_mouse_swap_hands() //Toggle whether middle click swaps your hands
 	prefs.toggle_prefs ^= TOGGLE_MIDDLE_MOUSE_SWAP_HANDS

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -802,7 +802,7 @@
 
 		// Overdoses are life-threatening
 		for (var/datum/reagent/reagent as anything in reagents.reagent_list)
-			if (reagent.volume > reagent.overdose)
+			if (reagent.volume > reagent.overdose && reagent.overdose != 0)
 				tag_severity = 2
 
 		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
@@ -824,7 +824,8 @@
 				tag_severity = 2
 				internal_bleeding = TRUE
 				break
-			if (internal_bleeding) break
+			if (internal_bleeding)
+				break
 
 			// Splinted fractures do not require immediate surgical intervention
 			// Unsplinted fractures should be handled immediately before more damage is done
@@ -841,29 +842,40 @@
 		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
 			// Heartbroken marines should be operated on IMMEDIATELY
 			var/datum/internal_organ/kidneys/heart = internal_organs_by_name["heart"]
-			if (heart.organ_status >= ORGAN_BROKEN) tag_severity = 2
-			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (heart.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (heart.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Ditto for ruptured lungs
 			var/datum/internal_organ/kidneys/lungs = internal_organs_by_name["lungs"]
-			if (is_lung_ruptured()) tag_severity = 2
-			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (is_lung_ruptured())
+				tag_severity = 2
+			else if (lungs.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Bruised livers and kidneys will accumulate toxin damage
-			// It's debatable whether or not this should be orange or red, but better safe than sorry
 			var/datum/internal_organ/kidneys/kidneys = internal_organs_by_name["kidneys"]
-			if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (kidneys.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (kidneys.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			var/datum/internal_organ/liver/liver = internal_organs_by_name["liver"]
-			if (liver.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (liver.organ_status >= ORGAN_BROKEN)
+				tag_severity = 2
+			else if (liver.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 			// Brainrot is bad
 			var/datum/internal_organ/brain/brain = internal_organs_by_name["brain"]
-			if (brain.organ_status >= ORGAN_BRUISED) tag_severity = 2
+			if (brain.organ_status >= ORGAN_BRUISED)
+				tag_severity = 2
 
 			// Eye damage is not nearly as bad as the previous three organs, and isn't NECESSARY to be fixed, technically
 			var/datum/internal_organ/eyes/eyes = internal_organs_by_name["eyes"]
-			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+			if (eyes.organ_status >= ORGAN_BRUISED)
+				tag_severity = max(tag_severity, 1)
 
 		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
 
@@ -875,7 +887,8 @@
 		if (head == null || head.status & (LIMB_DESTROYED | LIMB_AMPUTATED))
 			tag_severity = 3
 
-		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER) tag_severity = 4
+		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
+			tag_severity = 4
 
 		var/old_severity
 		// Yes, switching between strings and numbers like this is terrible and I should be using a custom define, but I don't want to touch the code already in place
@@ -905,6 +918,7 @@
 				if (4)
 					holo_card_color = "purple"
 			hud_set_holocard()
+
 
 /mob/living/carbon/human/tgui_interact(mob/user, datum/tgui/ui) // I'M SORRY, SO FUCKING SORRY
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -768,6 +768,7 @@
 		to_chat(user, SPAN_WARNING("[src] is too far away."))
 		return
 	if(newcolor == "none")
+		holo_card_accuracy = 0
 		if(!holo_card_color)
 			return
 		holo_card_color = null
@@ -775,7 +776,135 @@
 	else if(newcolor != holo_card_color)
 		holo_card_color = newcolor
 		to_chat(user, SPAN_NOTICE("You add a [newcolor] holo card on [src]."))
+	holo_card_accuracy = HOLOCARD_ACCURACY_MANUAL
 	hud_set_holocard()
+
+// Scans the health of a human, then assigns an appropriate holotag based on their injuries
+// Will use new_accuracy to determine both:
+//  - What injuries should be included (for example, organ damage would not show up on a handheld scan)
+//  - Whether to update a holotag to a more accurate reading, or to keep the old one
+// Manual assignments will not change the color of the holotag, but will change the recorded accuracy
+//
+// If a manual assignment or body scanner determines there are no injuries worthy of a holotag, it will reset the accuracy rating (clean slate)
+/mob/living/carbon/human/proc/auto_assign_holotag(mob/user, new_accuracy)
+	if (new_accuracy == HOLOCARD_ACCURACY_MANUAL)
+		holo_card_accuracy = HOLOCARD_ACCURACY_MANUAL
+		return
+
+	// Only handle automatic holotags if the user has the skill to
+	if (skillcheck(user, SKILL_MEDICAL, SKILL_MEDICAL_MEDIC))
+		var/tag_severity = 0
+
+		if (blood_volume < BLOOD_VOLUME_OKAY)
+			tag_severity = 2
+		else if (blood_volume < BLOOD_VOLUME_SAFE)
+			tag_severity = 1 // Severity could only ever be 0 at this point, safe to directly assign
+
+		// Overdoses are life-threatening
+		for (var/datum/reagent/reagent as anything in reagents.reagent_list)
+			if (reagent.volume > reagent.overdose)
+				tag_severity = 2
+
+		// The highest holotag you can get from limbs is red, so we can safely break out of the limb loop if we find a red-worthy injury
+		for (var/obj/limb/limb as anything in limbs)
+			// Uncleaned amputations, while technically not life threatening because amputations
+			// don't bleed, cause an incredible amount of pain, usually enough to paincrit the injured human.
+			if (limb.status & LIMB_DESTROYED)
+				tag_severity = 2
+				break
+
+			// An argument could be made for cleaned and dressed amputations to be red tag, but at that point
+			// it no longer causes any pain and only applies the slowdown/missing hand, so nonlethal
+			if (limb.status & LIMB_AMPUTATED)
+				tag_severity = max(tag_severity, 1)
+
+			// Internal bleeding requires immediate surgery
+			var/internal_bleeding = FALSE
+			for(var/datum/effects/bleeding/internal/ib in limb.bleeding_effects_list)
+				tag_severity = 2
+				internal_bleeding = TRUE
+				break
+			if (internal_bleeding) break
+
+			// Splinted fractures do not require immediate surgical intervention
+			// Unsplinted fractures should be handled immediately before more damage is done
+			if (limb.status & LIMB_BROKEN)
+				tag_severity = max(tag_severity, 1)
+
+/* // we dont have this
+			// Severe burns and eschars are not immediately life-threatening
+			if (limb.status & LIMB_ESCHAR)
+				tag_severity = max(tag_severity, 1)
+*/
+
+		// Check if this new scan would have had the accuracy to view organs
+		if (new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER)
+			// Heartbroken marines should be operated on IMMEDIATELY
+			var/datum/internal_organ/kidneys/heart = internal_organs_by_name["heart"]
+			if (heart.organ_status >= ORGAN_BROKEN) tag_severity = 2
+			else if (heart.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+
+			// Ditto for ruptured lungs
+			var/datum/internal_organ/kidneys/lungs = internal_organs_by_name["lungs"]
+			if (is_lung_ruptured()) tag_severity = 2
+			else if (lungs.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+
+			// Bruised livers and kidneys will accumulate toxin damage
+			// It's debatable whether or not this should be orange or red, but better safe than sorry
+			var/datum/internal_organ/kidneys/kidneys = internal_organs_by_name["kidneys"]
+			if (kidneys.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			var/datum/internal_organ/liver/liver = internal_organs_by_name["liver"]
+			if (liver.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			// Brainrot is bad
+			var/datum/internal_organ/brain/brain = internal_organs_by_name["brain"]
+			if (brain.organ_status >= ORGAN_BRUISED) tag_severity = 2
+
+			// Eye damage is not nearly as bad as the previous three organs, and isn't NECESSARY to be fixed, technically
+			var/datum/internal_organ/eyes/eyes = internal_organs_by_name["eyes"]
+			if (eyes.organ_status >= ORGAN_BRUISED) tag_severity = max(tag_severity, 1)
+
+		if (status_flags & PERMANENTLY_DEAD) tag_severity = 3
+
+		// For some reason, decapitated humans don't have the permanently dead tag
+		var/obj/limb/head/head
+		for (var/obj/limb/limb in src.limbs)
+			if (istype(limb, /obj/limb/head))
+				head = limb
+		if (head == null || head.status & (LIMB_DESTROYED | LIMB_AMPUTATED))
+			tag_severity = 3
+
+		if (status_flags & XENO_HOST && new_accuracy >= HOLOCARD_ACCURACY_BODYSCANNER) tag_severity = 4
+
+		var/old_severity
+		// Yes, switching between strings and numbers like this is terrible and I should be using a custom define, but I don't want to touch the code already in place
+		// Technical debt schmectical debt
+		switch (holo_card_color)
+			if("", null) old_severity = 0
+			if("orange") old_severity = 1
+			if("red") old_severity = 2
+			if("black") old_severity = 3
+			if("purple") old_severity = 4 // Even if they're unrevivable, we need to get the larva out
+			else old_severity = 0
+
+		// If the scan's accuracy is equal to or greater than the previous scan, or if the severity is higher than the old severity, update the card
+		if (tag_severity > old_severity || new_accuracy >= holo_card_accuracy)
+			holo_card_accuracy = new_accuracy
+			// See previous comment
+			switch (tag_severity)
+				if (0)
+					holo_card_color = ""
+					holo_card_accuracy = HOLOCARD_ACCURACY_HANDHELD // Reset accuracy for new wounds
+				if (1)
+					holo_card_color = "orange"
+				if (2)
+					holo_card_color = "red"
+				if (3)
+					holo_card_color = "black"
+				if (4)
+					holo_card_color = "purple"
+			hud_set_holocard()
 
 /mob/living/carbon/human/tgui_interact(mob/user, datum/tgui/ui) // I'M SORRY, SO FUCKING SORRY
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -89,6 +89,7 @@
 	var/undefibbable = FALSE //whether the human is dead and past the defibbrillation period.
 
 	var/holo_card_color = "" //which color type of holocard is printed on us
+	var/holo_card_accuracy = HOLOCARD_ACCURACY_HANDHELD // What placed this holocard on the human
 
 	var/list/obj/limb/limbs = list()
 	var/list/internal_organs_by_name = list() // so internal organs have less ickiness too


### PR DESCRIPTION
# About the pull request

Портирование одного из пулл реквестов с ПВП. Включает в себя автоматическое добавление голокард при сканировании пациента с помощью ручных или станционарных сканеров.

Также при желании это можно отключить или применить только к стационарным сканерам, всё в префах.

Кратко:
Оранжевый: Отложное - Требует хирургического или специального медицинского вмешательства, но отсутствие лечения не приведёт к вреду.
Красный: Неотложное - Требует хирургического или специального медицинского вмешательства, и отсутствие лечения будет продолжать причинять вред.
Чёрный: Погибший - клиническая смерть или ожидаемая смерть. В данном случае этот цвет зарезервирован для пехотинцев, получивших статус "перма-смерти".
Фиолетовый: Заражённый — специальная метка, обозначающая заражение XX-121.

Более подробное описание вы сможете прочитать по ссылке ниже.

Оригинал - https://github.com/cmss13-devs/cmss13/pull/12430
Фикс оригинала - https://github.com/cmss13-devs/cmss13/pull/12578

# Explain why it's good for the game

Потому что их наконец смогут люди вообще увидеть??
Да и в оригинальном пулл реквесте отписано, что это довольно "soulful" темка...

# Testing Photographs and Procedure

В оригинальном пулл реквесте есть видео.

# Changelog

:cl:
qol: Health scanners will now automatically apply the appropriate triage holocard.
/:cl:
